### PR TITLE
Launch/Build Arguments Handling

### DIFF
--- a/Sources/XcodeServerAPI/XCSBuildArgument.swift
+++ b/Sources/XcodeServerAPI/XCSBuildArgument.swift
@@ -1,5 +1,0 @@
-import Foundation
-
-public struct XCSBuildArgument: Codable {
-    
-}

--- a/Sources/XcodeServerAPI/XCSConfiguration.swift
+++ b/Sources/XcodeServerAPI/XCSConfiguration.swift
@@ -1,6 +1,8 @@
 import Foundation
 import XcodeServerCommon
 
+public typealias XCSBuildArgument = String
+
 public struct XCSConfiguration: Codable {
     public var schemeName: String?
     


### PR DESCRIPTION
Corrected handling of Launch/Build arguments on the API. The expected type is an array of 'String' not _object_.