### PR TITLE
Stats Operations

### DIFF
--- a/Sources/XcodeServerAPI/XCSClient.swift
+++ b/Sources/XcodeServerAPI/XCSClient.swift
@@ -6,7 +6,7 @@ import SWCompression
 import FoundationNetworking
 #endif
 
-public protocol CredentialDelegate: class {
+public protocol CredentialDelegate: AnyObject {
     func credentials(for server: Server.ID) -> (username: String, password: String)?
 }
 

--- a/Sources/XcodeServerModel_1_0_0/Entities/Stats.swift
+++ b/Sources/XcodeServerModel_1_0_0/Entities/Stats.swift
@@ -135,6 +135,9 @@ extension Stats {
                 bestSuccessStreak = existing
             } else {
                 let new: Integration = context.make()
+                // In the instance where Stats are retrieved before the integration details,
+                // The relationship to the bot needs to be established.
+                new.bot = self.bot
                 new.update(integration, context: context)
                 bestSuccessStreak = new
             }
@@ -145,6 +148,9 @@ extension Stats {
                 lastCleanIntegration = existing
             } else {
                 let new: Integration = context.make()
+                // In the instance where Stats are retrieved before the integration details,
+                // The relationship to the bot needs to be established.
+                new.bot = self.bot
                 new.update(integration, context: context)
                 lastCleanIntegration = new
             }

--- a/Sources/XcodeServerModel_1_1_0/Entities/Stats.swift
+++ b/Sources/XcodeServerModel_1_1_0/Entities/Stats.swift
@@ -135,6 +135,9 @@ extension Stats {
                 bestSuccessStreak = existing
             } else {
                 let new: Integration = context.make()
+                // In the instance where Stats are retrieved before the integration details,
+                // The relationship to the bot needs to be established.
+                new.bot = self.bot
                 new.update(integration, context: context)
                 bestSuccessStreak = new
             }
@@ -145,6 +148,9 @@ extension Stats {
                 lastCleanIntegration = existing
             } else {
                 let new: Integration = context.make()
+                // In the instance where Stats are retrieved before the integration details,
+                // The relationship to the bot needs to be established.
+                new.bot = self.bot
                 new.update(integration, context: context)
                 lastCleanIntegration = new
             }

--- a/Sources/XcodeServerProcedures/SyncIntegrationProcedure.swift
+++ b/Sources/XcodeServerProcedures/SyncIntegrationProcedure.swift
@@ -50,6 +50,8 @@ extension SyncIntegrationProcedure: ProcedureQueueDelegate {
     }
     
     public func procedureQueue(_ queue: ProcedureQueue, didFinishProcedure procedure: Procedure, with error: Error?) {
+        InternalLog.operations.debug("Finished Procedure '\(procedure)' \(error?.localizedDescription ?? "")")
+        
         switch procedure {
         case is UpdateIntegrationProcedure:
             let getOutput = GetIntegrationProcedure(source: destination, input: integration.id)

--- a/Sources/XcodeServerProcedures/SyncServerProcedure.swift
+++ b/Sources/XcodeServerProcedures/SyncServerProcedure.swift
@@ -60,6 +60,8 @@ extension SyncServerProcedure: ProcedureQueueDelegate {
     }
     
     public func procedureQueue(_ queue: ProcedureQueue, didFinishProcedure procedure: Procedure, with error: Error?) {
+        InternalLog.operations.debug("Finished Procedure '\(procedure)' \(error?.localizedDescription ?? "")")
+        
         switch procedure {
         case is UpdateServerBotsProcedure:
             let getOutput = GetBotsProcedure(source: destination, serverId: server.id)

--- a/Sources/XcodeServerUtility/Manager.swift
+++ b/Sources/XcodeServerUtility/Manager.swift
@@ -626,7 +626,7 @@ extension Manager: ProcedureQueueDelegate {
     }
     
     public func procedureQueue(_ queue: ProcedureQueue, didFinishProcedure procedure: Procedure, with error: Swift.Error?) {
-        
+        InternalLog.operations.debug("Finished Procedure '\(procedure)' \(error?.localizedDescription ?? "")")
     }
 }
 


### PR DESCRIPTION
A potential bug is addressed with this PR. When the `Bot.Stats` are retrieved before the `Bot.Integrations`, an `Integration` can be created in Core Data that didn't have a relationship to its `Bot`. The bot relationship will now be set correctly, and the order of operations places the stats retrieval after the other syncing.