### PR TITLE
Cascade Syncing

### DIFF
--- a/Documentation/xcscli.md
+++ b/Documentation/xcscli.md
@@ -58,8 +58,8 @@ On Apple platforms this command will download and persist data from a requested 
 
 * **info**: Retrieves versioning information about a persistence store (model version)
 
-* **sync**: Initiates a sync for a specific server, retrieving Bots and their associated Integrations.
+* **sync**: Sync a specific server, retrieving Bots and any associated Integrations.
 
 * **delete-server**: Removes the data for a single Xcode Server from the persistence store.
 
-* **purge**: Remote the local persistence store from disk.
+* **purge**: Remove the local persistence store from disk.

--- a/Documentation/xcscli.md
+++ b/Documentation/xcscli.md
@@ -52,6 +52,14 @@ additional resources.
 
 * **coverage**: Unit testing coverage data (can take a while).
 
-#### sync
+#### store
 
 On Apple platforms this command will download and persist data from a requested server.
+
+* **info**: Retrieves versioning information about a persistence store (model version)
+
+* **sync**: Initiates a sync for a specific server, retrieving Bots and their associated Integrations.
+
+* **delete-server**: Removes the data for a single Xcode Server from the persistence store.
+
+* **purge**: Remote the local persistence store from disk.

--- a/Sources/XcodeServer/Protocols/Persistable.swift
+++ b/Sources/XcodeServer/Protocols/Persistable.swift
@@ -3,18 +3,32 @@ import Foundation
 public protocol ServerPersistable {
     func persistServer(_ server: Server) async throws -> Server
     func removeServer(withId id: Server.ID) async throws
-    func persistBots(_ bots: [Bot], forServer id: Server.ID) async throws -> [Bot]
 }
 
 public protocol BotPersistable {
     func persistBot(_ bot: Bot, forServer id: Server.ID) async throws -> Bot
+    /// Persists the provided `Bot` collection and associates to the `Server` with the specified `Server.ID`.
+    ///
+    /// - parameters:
+    ///   - bots: The `Bot` collection that needs persistence (updates).
+    ///   - id: The ID/FQDN of the `Server` for which to associate the provided `Bot`s.
+    ///   - cascadeDelete: When enabled, the provided collection should be assumed to represent the new state and any persisted bots that are not represented
+    ///                    should be deleted.
+    func persistBots(_ bots: [Bot], forServer id: Server.ID, cascadeDelete: Bool) async throws -> [Bot]
     func removeBot(withId id: Bot.ID) async throws
     func persistStats(_ stats: Bot.Stats, forBot id: Bot.ID) async throws -> Bot.Stats
 }
 
 public protocol IntegrationPersistable {
     func persistIntegration(_ integration: Integration, forBot id: Bot.ID) async throws -> Integration
-    func persistIntegrations(_ integrations: [Integration], forBot id: Bot.ID) async throws -> [Integration]
+    /// Persists the provided `Integration` collection and associates to the `Bot` with the specified `Bot.ID`.
+    ///
+    /// - parameters:
+    ///   - integrations: The `Integration` collection that needs persistence (updates).
+    ///   - id: The ID of the `Bot` for which to associate the provided `Integration`s.
+    ///   - cascadeDelete: When enabled, the provided collection should be assumed to represent the new state and any persisted integrations that are not
+    ///                    represented should be deleted.
+    func persistIntegrations(_ integrations: [Integration], forBot id: Bot.ID, cascadeDelete: Bool) async throws -> [Integration]
     func removeIntegration(withId id: Integration.ID) async throws
     func persistCommits(_ commits: [SourceControl.Commit], forIntegration id: Integration.ID) async throws -> [SourceControl.Commit]
     func persistIssues(_ issues: Integration.IssueCatalog, forIntegration id: Integration.ID) async throws -> Integration.IssueCatalog
@@ -33,3 +47,21 @@ public protocol EntityPersistable:
 
 @available(*, deprecated, renamed: "EntityPersistable")
 public typealias AnyPersistable = EntityPersistable
+
+public extension BotPersistable {
+    /// Persists the provided `Bot` collection and associates to the `Server` with the specified `Server.ID`.
+    ///
+    /// Convenience implementation that mirrors the previous signature, passing `false` to the `cascadeDelete` parameter.
+    func persistBots(_ bots: [Bot], forServer id: Server.ID) async throws -> [Bot] {
+        try await persistBots(bots, forServer: id, cascadeDelete: false)
+    }
+}
+
+public extension IntegrationPersistable {
+    /// Persists the provided `Integration` collection and associates to the `Bot` with the specified `Bot.ID`.
+    ///
+    /// Convenience implementation that mirrors the previous signature, passing `false` to the `cascadeDelete` parameter.
+    func persistIntegrations(_ integrations: [Integration], forBot id: Bot.ID) async throws -> [Integration] {
+        try await persistIntegrations(integrations, forBot: id, cascadeDelete: false)
+    }
+}

--- a/Sources/XcodeServerAPI/XCSClient.swift
+++ b/Sources/XcodeServerAPI/XCSClient.swift
@@ -171,6 +171,20 @@ public class XCSClient: URLSessionClient {
         Self.logger.info("Retrieving XCSBot [\(id)]")
         let request = try clientRequest(path: "bots/\(id)")
         let response = try await performRequest(request)
+        
+        switch response.statusCode {
+        case .notFound:
+            throw XcodeServerError.botNotFound(id)
+        case .ok:
+            break
+        default:
+            Self.logger.warning("Unexpected HTTP Status Code", metadata: [
+                "Bot.ID": .string(id),
+                "StatusCode": .stringConvertible(response.statusCode),
+                "Body": .string(String(data: response.data, encoding: .utf8) ?? "")
+            ])
+        }
+        
         return try jsonDecoder.decode(XCSBot.self, from: response.data)
     }
     
@@ -178,6 +192,20 @@ public class XCSClient: URLSessionClient {
         Self.logger.info("Retrieving XCSStats for Bot [\(id)]")
         let request = try clientRequest(path: "bots/\(id)/stats")
         let response = try await performRequest(request)
+        
+        switch response.statusCode {
+        case .notFound:
+            throw XcodeServerError.botNotFound(id)
+        case .ok:
+            break
+        default:
+            Self.logger.warning("Unexpected HTTP Status Code", metadata: [
+                "Bot.ID": .string(id),
+                "StatusCode": .stringConvertible(response.statusCode),
+                "Body": .string(String(data: response.data, encoding: .utf8) ?? "")
+            ])
+        }
+        
         return try jsonDecoder.decode(XCSStats.self, from: response.data)
     }
     
@@ -200,6 +228,20 @@ public class XCSClient: URLSessionClient {
         Self.logger.info("Retrieving XCSIntegration [\(id)]")
         let request = try clientRequest(path: "integrations/\(id)")
         let response = try await performRequest(request)
+        
+        switch response.statusCode {
+        case .notFound:
+            throw XcodeServerError.integrationNotFound(id)
+        case .ok:
+            break
+        default:
+            Self.logger.warning("Unexpected HTTP Status Code", metadata: [
+                "Integration.ID": .string(id),
+                "StatusCode": .stringConvertible(response.statusCode),
+                "Body": .string(String(data: response.data, encoding: .utf8) ?? "")
+            ])
+        }
+        
         return try jsonDecoder.decode(XCSIntegration.self, from: response.data)
     }
     
@@ -214,6 +256,20 @@ public class XCSClient: URLSessionClient {
         let request = try clientRequest(path: "bots/\(id)/integrations")
         let response = try await performRequest(request)
         let results = try jsonDecoder.decode(Response.self, from: response.data)
+        
+        switch response.statusCode {
+        case .notFound:
+            throw XcodeServerError.botNotFound(id)
+        case .ok:
+            break
+        default:
+            Self.logger.warning("Unexpected HTTP Status Code", metadata: [
+                "Bot.ID": .string(id),
+                "StatusCode": .stringConvertible(response.statusCode),
+                "Body": .string(String(data: response.data, encoding: .utf8) ?? "")
+            ])
+        }
+        
         return results.results
     }
     
@@ -222,6 +278,20 @@ public class XCSClient: URLSessionClient {
         Self.logger.info("Requesting XCSIntegration for BOT [\(id)]")
         let request = try clientRequest(path: "bots/\(id)/integrations", method: .post)
         let response = try await performRequest(request)
+        
+        switch response.statusCode {
+        case .notFound:
+            throw XcodeServerError.botNotFound(id)
+        case .ok:
+            break
+        default:
+            Self.logger.warning("Unexpected HTTP Status Code", metadata: [
+                "Bot.ID": .string(id),
+                "StatusCode": .stringConvertible(response.statusCode),
+                "Body": .string(String(data: response.data, encoding: .utf8) ?? "")
+            ])
+        }
+        
         return try jsonDecoder.decode(XCSIntegration.self, from: response.data)
     }
     
@@ -235,6 +305,20 @@ public class XCSClient: URLSessionClient {
         
         let request = try clientRequest(path: "integrations/\(id)/commits")
         let response = try await performRequest(request)
+        
+        switch response.statusCode {
+        case .notFound:
+            throw XcodeServerError.integrationNotFound(id)
+        case .ok:
+            break
+        default:
+            Self.logger.warning("Unexpected HTTP Status Code", metadata: [
+                "Integration.ID": .string(id),
+                "StatusCode": .stringConvertible(response.statusCode),
+                "Body": .string(String(data: response.data, encoding: .utf8) ?? "")
+            ])
+        }
+        
         let results = try jsonDecoder.decode(Response.self, from: response.data)
         return results.results
     }
@@ -244,6 +328,20 @@ public class XCSClient: URLSessionClient {
         Self.logger.info("Retrieving XCSIssues for INTEGRATION [\(id)]")
         let request = try clientRequest(path: "integrations/\(id)/issues")
         let response = try await performRequest(request)
+        
+        switch response.statusCode {
+        case .notFound:
+            throw XcodeServerError.integrationNotFound(id)
+        case .ok:
+            break
+        default:
+            Self.logger.warning("Unexpected HTTP Status Code", metadata: [
+                "Integration.ID": .string(id),
+                "StatusCode": .stringConvertible(response.statusCode),
+                "Body": .string(String(data: response.data, encoding: .utf8) ?? "")
+            ])
+        }
+        
         return try jsonDecoder.decode(XCSIssues.self, from: response.data)
     }
     

--- a/Sources/XcodeServerCoreData/CoreDataStore.swift
+++ b/Sources/XcodeServerCoreData/CoreDataStore.swift
@@ -132,6 +132,10 @@ extension CoreDataStore: EntityPersistable {
         try await entityPersistable.persistBot(bot, forServer: id)
     }
     
+    public func persistBots(_ bots: [Bot], forServer id: Server.ID, cascadeDelete: Bool) async throws -> [Bot] {
+        try await entityPersistable.persistBots(bots, forServer: id, cascadeDelete: cascadeDelete)
+    }
+    
     public func removeBot(withId id: XcodeServer.Bot.ID) async throws {
         try await entityPersistable.removeBot(withId: id)
     }
@@ -145,8 +149,8 @@ extension CoreDataStore: EntityPersistable {
         try await entityPersistable.persistIntegration(integration, forBot: id)
     }
     
-    public func persistIntegrations(_ integrations: [XcodeServer.Integration], forBot id: XcodeServer.Bot.ID) async throws -> [XcodeServer.Integration] {
-        try await entityPersistable.persistIntegrations(integrations, forBot: id)
+    public func persistIntegrations(_ integrations: [XcodeServer.Integration], forBot id: XcodeServer.Bot.ID, cascadeDelete: Bool) async throws -> [XcodeServer.Integration] {
+        try await entityPersistable.persistIntegrations(integrations, forBot: id, cascadeDelete: cascadeDelete)
     }
     
     public func removeIntegration(withId id: XcodeServer.Integration.ID) async throws {
@@ -172,10 +176,6 @@ extension CoreDataStore: EntityPersistable {
     
     public func removeServer(withId id: Server.ID) async throws {
         try await entityPersistable.removeServer(withId: id)
-    }
-    
-    public func persistBots(_ bots: [Bot], forServer id: Server.ID) async throws -> [Bot] {
-        try await entityPersistable.persistBots(bots, forServer: id)
     }
     
     // MARK: - SourceControlPersistable

--- a/Sources/XcodeServerModel_1_0_0/PersistentContainer+Persistable.swift
+++ b/Sources/XcodeServerModel_1_0_0/PersistentContainer+Persistable.swift
@@ -26,19 +26,6 @@ extension PersistentContainer: ServerPersistable {
             context.delete(server)
         }
     }
-    
-    public func persistBots(_ bots: [XcodeServer.Bot], forServer id: XcodeServer.Server.ID) async throws -> [XcodeServer.Bot] {
-        var results: [XcodeServer.Bot]!
-        try newBackgroundContext().performSynchronously { context in
-            guard let server = Server.server(id, in: context) else {
-                throw XcodeServerError.serverNotFound(id)
-            }
-            
-            server.update(Set(bots), context: context)
-            results = (server.bots as? Set<Bot> ?? []).map { XcodeServer.Bot($0) }
-        }
-        return results
-    }
 }
 
 extension PersistentContainer: BotPersistable {
@@ -63,6 +50,19 @@ extension PersistentContainer: BotPersistable {
             result = XcodeServer.Bot(_bot)
         }
         return result
+    }
+    
+    public func persistBots(_ bots: [XcodeServer.Bot], forServer id: XcodeServer.Server.ID, cascadeDelete: Bool) async throws -> [XcodeServer.Bot] {
+        var results: [XcodeServer.Bot]!
+        try newBackgroundContext().performSynchronously { context in
+            guard let server = Server.server(id, in: context) else {
+                throw XcodeServerError.serverNotFound(id)
+            }
+            
+            server.update(Set(bots), context: context)
+            results = (server.bots as? Set<Bot> ?? []).map { XcodeServer.Bot($0) }
+        }
+        return results
     }
     
     public func removeBot(withId id: XcodeServer.Bot.ID) async throws {
@@ -117,7 +117,7 @@ extension PersistentContainer: IntegrationPersistable {
         return result
     }
     
-    public func persistIntegrations(_ integrations: [XcodeServer.Integration], forBot id: XcodeServer.Bot.ID) async throws -> [XcodeServer.Integration] {
+    public func persistIntegrations(_ integrations: [XcodeServer.Integration], forBot id: XcodeServer.Bot.ID, cascadeDelete: Bool) async throws -> [XcodeServer.Integration] {
         var results: [XcodeServer.Integration] = []
         try newBackgroundContext().performSynchronously { context in
             for integration in integrations {

--- a/Sources/XcodeServerModel_1_1_0/PersistentContainer+Persistable.swift
+++ b/Sources/XcodeServerModel_1_1_0/PersistentContainer+Persistable.swift
@@ -33,19 +33,6 @@ extension PersistentContainer: ServerPersistable {
             context.delete(server)
         }
     }
-    
-    public func persistBots(_ bots: [XcodeServer.Bot], forServer id: XcodeServer.Server.ID) async throws -> [XcodeServer.Bot] {
-        var results: [XcodeServer.Bot]!
-        try persistenceContext.performSynchronously { context in
-            guard let server = Server.server(id, in: context) else {
-                throw XcodeServerError.serverNotFound(id)
-            }
-            
-            server.update(Set(bots), context: context)
-            results = (server.bots as? Set<Bot> ?? []).map { XcodeServer.Bot($0) }
-        }
-        return results
-    }
 }
 
 extension PersistentContainer: BotPersistable {
@@ -74,6 +61,19 @@ extension PersistentContainer: BotPersistable {
             result = XcodeServer.Bot(_bot)
         }
         return result
+    }
+    
+    public func persistBots(_ bots: [XcodeServer.Bot], forServer id: XcodeServer.Server.ID, cascadeDelete: Bool) async throws -> [XcodeServer.Bot] {
+        var results: [XcodeServer.Bot]!
+        try persistenceContext.performSynchronously { context in
+            guard let server = Server.server(id, in: context) else {
+                throw XcodeServerError.serverNotFound(id)
+            }
+            
+            server.update(Set(bots), context: context)
+            results = (server.bots as? Set<Bot> ?? []).map { XcodeServer.Bot($0) }
+        }
+        return results
     }
     
     public func removeBot(withId id: XcodeServer.Bot.ID) async throws {
@@ -134,7 +134,7 @@ extension PersistentContainer: IntegrationPersistable {
         return result
     }
     
-    public func persistIntegrations(_ integrations: [XcodeServer.Integration], forBot id: XcodeServer.Bot.ID) async throws -> [XcodeServer.Integration] {
+    public func persistIntegrations(_ integrations: [XcodeServer.Integration], forBot id: XcodeServer.Bot.ID, cascadeDelete: Bool) async throws -> [XcodeServer.Integration] {
         var results: [XcodeServer.Integration] = []
         try persistenceContext.performSynchronously { context in
             for integration in integrations {

--- a/Sources/XcodeServerModel_2_0_0/Entities/ManagedBot.swift
+++ b/Sources/XcodeServerModel_2_0_0/Entities/ManagedBot.swift
@@ -142,6 +142,10 @@ extension ManagedBot {
             }
             
             integrationsToRemove.forEach { managedIntegration in
+                PersistentContainer.logger.info("Deleting `ManagedIntegration`.", metadata: [
+                    "Integration.ID": .string(managedIntegration.identifier ?? ""),
+                    "Integration.Number": .stringConvertible(managedIntegration.number),
+                ])
                 context.delete(managedIntegration)
             }
         }

--- a/Sources/XcodeServerModel_2_0_0/Entities/ManagedServer.swift
+++ b/Sources/XcodeServerModel_2_0_0/Entities/ManagedServer.swift
@@ -121,6 +121,10 @@ extension ManagedServer {
             }
             
             botsToRemove.forEach { managedBot in
+                PersistentContainer.logger.info("Deleting `ManagedBot`.", metadata: [
+                    "Bot.ID": .string(managedBot.identifier ?? ""),
+                    "Bot.Name": .string(managedBot.name ?? ""),
+                ])
                 context.delete(managedBot)
             }
         }

--- a/Sources/XcodeServerModel_2_0_0/PersistentContainer+Persistable.swift
+++ b/Sources/XcodeServerModel_2_0_0/PersistentContainer+Persistable.swift
@@ -143,28 +143,6 @@ extension PersistentContainer: IntegrationPersistable {
             
             bot.update(integrations, cascadeDelete: cascadeDelete, context: context)
             results = (bot.integrations as? Set<ManagedIntegration> ?? []).map { Integration($0) }
-            
-//            for integration in integrations {
-//                let _integration: ManagedIntegration
-//                if let existing = ManagedIntegration.integration(integration.id, in: context) {
-//                    _integration = existing
-//                    if _integration.bot == nil {
-//                        _integration.bot = ManagedBot.bot(id, in: context)
-//                    }
-//                } else {
-//                    guard let bot = ManagedBot.bot(id, in: context) else {
-//                        throw XcodeServerError.botNotFound(id)
-//                    }
-//
-//                    PersistentContainer.logger.info("Creating INTEGRATION '\(integration.number)' [\(integration.id)]")
-//                    _integration = context.make()
-//                    _integration.bot = bot
-//                }
-//
-//                _integration.update(integration, context: context)
-//
-//                results.append(Integration(_integration))
-//            }
         }
         return results
     }

--- a/Sources/xcscli/Bots.swift
+++ b/Sources/xcscli/Bots.swift
@@ -4,7 +4,7 @@ import XcodeServer
 import XcodeServerAPI
 import Logging
 
-final class Bots: AsyncParsableCommand, Route, Logged {
+final class Bots: AsyncParsableCommand, Routed, Credentialed, Logged {
     
     static var configuration: CommandConfiguration = {
         return CommandConfiguration(

--- a/Sources/xcscli/Bots.swift
+++ b/Sources/xcscli/Bots.swift
@@ -42,30 +42,46 @@ final class Bots: AsyncParsableCommand, Route, Logged {
     var path: Path?
     
     @Option(help: "The minimum output log level.")
-    var logLevel: Logger.Level = .warning
+    var logLevel: Logger.Level = .notice
     
     func validate() throws {
         try validateServer()
     }
     
     func run() async throws {
+        ConsoleLogger.bootstrap(minimumLogLevel: logLevel)
+        
         let client = try XCSClient(fqdn: server, credentialDelegate: self)
-        switch (id) {
-        case .some(let id) where path == .some(.stats):
-            let stats: Bot.Stats = try await client.stats(forBot: id)
-            print(stats.asPrettyJSON() ?? "OK")
-        case .some(let id) where path == .some(.integrations):
-            let integrations: [Integration] = try await client.integrations(forBot: id)
-            print(integrations.asPrettyJSON() ?? "OK")
-        case .some(let id) where path == .some(.run):
-            let integration = try await client.runIntegration(forBot: id)
-            print(integration.asPrettyJSON() ?? "OK")
-        case .some(let id) where path == .none:
-            let bot: Bot = try await client.bot(withId: id)
-            print(bot.asPrettyJSON() ?? "OK")
-        default:
-            let bots: [Bot] = try await client.bots()
-            print(bots.asPrettyJSON() ?? "OK")
+        
+        do {
+            switch (id) {
+            case .some(let id) where path == .some(.stats):
+                Logger.xcscli.notice("Retrieving Stats For Bot [\(id)]")
+                let stats: Bot.Stats = try await client.stats(forBot: id)
+                print(stats.asPrettyJSON() ?? "OK")
+            case .some(let id) where path == .some(.integrations):
+                Logger.xcscli.notice("Retrieving Integrations For Bot [\(id)]")
+                let integrations: [Integration] = try await client.integrations(forBot: id)
+                print(integrations.asPrettyJSON() ?? "OK")
+            case .some(let id) where path == .some(.run):
+                Logger.xcscli.notice("Triggering Integration For Bot [\(id)]")
+                let integration = try await client.runIntegration(forBot: id)
+                print(integration.asPrettyJSON() ?? "OK")
+            case .some(let id) where path == .none:
+                Logger.xcscli.notice("Retrieving Bot [\(id)]")
+                let bot: Bot = try await client.bot(withId: id)
+                print(bot.asPrettyJSON() ?? "OK")
+            default:
+                Logger.xcscli.notice("Retrieving Bots For Server [\(server)]")
+                let bots: [Bot] = try await client.bots()
+                print(bots.asPrettyJSON() ?? "OK")
+            }
+        } catch let xcsError as XcodeServerError {
+            if case .botNotFound(let id) = xcsError {
+                Logger.xcscli.error("Bot '\(id)' does not exist, or has been deleted.")
+            } else {
+                throw xcsError
+            }
         }
     }
 }

--- a/Sources/xcscli/Extensions/Logger.Level+xcscli.swift
+++ b/Sources/xcscli/Extensions/Logger.Level+xcscli.swift
@@ -2,3 +2,34 @@ import ArgumentParser
 import Logging
 
 extension Logger.Level: ExpressibleByArgument {}
+
+extension Logger.Level {
+    /// A unique visual indicator for each `Level`.
+    var gem: String {
+        switch self {
+        case .trace: return "🚰"
+        case .debug: return "🦠"
+        case .info: return "🔎"
+        case .notice: return "💡"
+        case .warning: return "🔮"
+        case .error: return "🚫"
+        case .critical: return "💣"
+        }
+    }
+    
+    /// A padded representation of the `Level`.
+    var fixedWidthDescription: String {
+        let max = Logger.Level.allCases.map { $0.rawValue.count }.max() ?? rawValue.count
+        return rawValue.padding(toLength: max, withPad: " ", startingAt: 0)
+    }
+}
+
+extension Logger.Level: CustomStringConvertible {
+    public var description: String {
+        "\(gem) \(fixedWidthDescription.uppercased())"
+    }
+}
+
+extension Logger {
+    static let xcscli: Logger = Logger(label: "xcscli")
+}

--- a/Sources/xcscli/Integrations.swift
+++ b/Sources/xcscli/Integrations.swift
@@ -4,7 +4,7 @@ import XcodeServer
 import XcodeServerAPI
 import Logging
 
-final class Integrations: AsyncParsableCommand, Route, Logged {
+final class Integrations: AsyncParsableCommand, Routed, Credentialed, Logged {
     
     static var configuration: CommandConfiguration = {
         return CommandConfiguration(

--- a/Sources/xcscli/Ping.swift
+++ b/Sources/xcscli/Ping.swift
@@ -4,7 +4,7 @@ import XcodeServer
 import XcodeServerAPI
 import Logging
 
-final class Ping: AsyncParsableCommand, Route, Logged {
+final class Ping: AsyncParsableCommand, Routed, Credentialed, Logged {
     
     static var configuration: CommandConfiguration = {
         return CommandConfiguration(

--- a/Sources/xcscli/Protocols/Credentialed.swift
+++ b/Sources/xcscli/Protocols/Credentialed.swift
@@ -4,25 +4,13 @@ import XcodeServer
 import XcodeServerAPI
 import Logging
 
-protocol Route: CredentialDelegate {
-    var server: String { get set }
+protocol Credentialed: CredentialDelegate {
     var username: String? { get set }
     var password: String? { get set }
-    var logLevel: Logger.Level { get set }
 }
 
-extension Route {
-    func validateServer() throws {
-        guard !server.isEmpty else {
-            throw ValidationError("Hostname not provided or empty.")
-        }
-        
-        guard let _ = URL(string: server) else {
-            throw ValidationError("Malformed Hostname: '\(server)'")
-        }
-    }
-    
-    // MARK: - XCSClient CredentialDelegate
+// MARK: - XCSClient CredentialDelegate
+extension Credentialed {
     func credentials(for server: Server.ID) -> (username: String, password: String)? {
         guard let username = self.username else {
             return nil

--- a/Sources/xcscli/Protocols/Routed.swift
+++ b/Sources/xcscli/Protocols/Routed.swift
@@ -1,0 +1,18 @@
+import Foundation
+import ArgumentParser
+
+protocol Routed {
+    var server: String { get set }
+}
+
+extension Routed {
+    func validateServer() throws {
+        guard !server.isEmpty else {
+            throw ValidationError("Hostname not provided or empty.")
+        }
+        
+        guard let _ = URL(string: server) else {
+            throw ValidationError("Malformed Hostname: '\(server)'")
+        }
+    }
+}

--- a/Sources/xcscli/Protocols/Stored.swift
+++ b/Sources/xcscli/Protocols/Stored.swift
@@ -3,6 +3,7 @@ import ArgumentParser
 import XcodeServer
 import XcodeServerCoreData
 import CoreDataPlus
+#if canImport(CoreData)
 
 protocol Stored {
     /// Persisted store path
@@ -12,7 +13,6 @@ protocol Stored {
     var model: Model? { get set }
 }
 
-#if canImport(CoreData)
 extension Stored {
     var storeURL: StoreURL {
         guard let path = self.path else {

--- a/Sources/xcscli/Protocols/Stored.swift
+++ b/Sources/xcscli/Protocols/Stored.swift
@@ -7,6 +7,9 @@ import CoreDataPlus
 protocol Stored {
     /// Persisted store path
     var path: String? { get set }
+    
+    /// The model version to use when accessing the store
+    var model: Model? { get set }
 }
 
 #if canImport(CoreData)

--- a/Sources/xcscli/Store+DeleteServer.swift
+++ b/Sources/xcscli/Store+DeleteServer.swift
@@ -7,12 +7,12 @@ import Logging
 #if canImport(CoreData)
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-final class StoreInfo: AsyncParsableCommand, Stored, Logged {
+final class StoreDeleteServer: AsyncParsableCommand, Routed, Stored, Logged {
     
     static var configuration: CommandConfiguration = {
         .init(
-            commandName: "info",
-            abstract: "Displays information about the persistence store.",
+            commandName: "delete-server",
+            abstract: "Delete a specified server from the store.",
             usage: nil,
             discussion: """
             When no 'path' is specified, the default store URL will be used:
@@ -26,24 +26,41 @@ final class StoreInfo: AsyncParsableCommand, Stored, Logged {
         )
     }()
     
+    @Argument(help: "Fully Qualified Domain Name of the Xcode Server.")
+    var server: String
+    
     @Argument(help: "Persisted store path")
     var path: String?
     
-    @Option(help: "IGNORED - The model version to use. [2.0.0].")
+    @Option(help: "The model version to use. [2.0.0].")
     var model: Model?
     
     @Option(help: "The minimum output log level.")
     var logLevel: Logger.Level = .info
     
+    func validate() throws {
+        try validateServer()
+    }
+    
     func run() async throws {
         ConsoleLogger.bootstrap(minimumLogLevel: logLevel)
         
-        let version = try Model.versionForStore(storeURL, configurationName: .configurationName)
+        let _model = model ?? Model.current
+        var store: CoreDataStore! = try CoreDataStore(model: _model, persistence: .store(storeURL))
         
-        Logger.xcscli.notice("Store Info", metadata: [
-            "StoreURL": .string(storeURL.rawValue.path),
-            "ModelVersion": .string(version?.rawValue ?? "UNKNOWN")
+        let start = Date()
+        
+        Logger.xcscli.notice("Removing SERVER [\(server)]")
+        try await store.removeServer(withId: server)
+        
+        let end = Date()
+        Logger.xcscli.notice("Server '\(server)' Removed", metadata: [
+            "Seconds": .string("\(end.timeIntervalSince(start))"),
+            "StoreURL": .string(storeURL.rawValue.path)
         ])
+        
+        // Cleanup
+        store = nil
     }
 }
 

--- a/Sources/xcscli/Store+Purge.swift
+++ b/Sources/xcscli/Store+Purge.swift
@@ -7,12 +7,12 @@ import Logging
 #if canImport(CoreData)
 
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
-final class StoreInfo: AsyncParsableCommand, Stored, Logged {
+final class StorePurge: AsyncParsableCommand, Stored, Logged {
     
     static var configuration: CommandConfiguration = {
         .init(
-            commandName: "info",
-            abstract: "Displays information about the persistence store.",
+            commandName: "purge",
+            abstract: "Purges the local persistence store.",
             usage: nil,
             discussion: """
             When no 'path' is specified, the default store URL will be used:
@@ -38,12 +38,9 @@ final class StoreInfo: AsyncParsableCommand, Stored, Logged {
     func run() async throws {
         ConsoleLogger.bootstrap(minimumLogLevel: logLevel)
         
-        let version = try Model.versionForStore(storeURL, configurationName: .configurationName)
-        
-        Logger.xcscli.notice("Store Info", metadata: [
-            "StoreURL": .string(storeURL.rawValue.path),
-            "ModelVersion": .string(version?.rawValue ?? "UNKNOWN")
-        ])
+        Logger.xcscli.notice("Purging Store")
+        try storeURL.destroy()
+        Logger.xcscli.notice("Purge Complete")
     }
 }
 

--- a/Sources/xcscli/Store.swift
+++ b/Sources/xcscli/Store.swift
@@ -16,7 +16,10 @@ final class Store: AsyncParsableCommand {
             version: "0.1",
             shouldDisplay: true,
             subcommands: [
-                StoreInfo.self
+                StoreInfo.self,
+                StoreSync.self,
+                StoreDeleteServer.self,
+                StorePurge.self,
             ],
             defaultSubcommand: nil,
             helpNames: [.short, .long]

--- a/Sources/xcscli/Sync.swift
+++ b/Sources/xcscli/Sync.swift
@@ -10,8 +10,6 @@ import Logging
 @available(macOS 10.15, iOS 13.0, tvOS 13.0, watchOS 6.0, *)
 final class Sync: AsyncParsableCommand, Route, Stored, Logged {
     
-    private static let logger: Logger = Logger(label: "Sync")
-    
     static var configuration: CommandConfiguration = {
         return CommandConfiguration(
             commandName: "sync",
@@ -68,7 +66,7 @@ final class Sync: AsyncParsableCommand, Route, Stored, Logged {
         _ = try await store.persistServer(_server)
         
         // Sync
-        Self.logger.notice("Syncing SERVER [\(server)]")
+        Logger.xcscli.notice("Syncing SERVER [\(server)]")
         let start = Date()
         
         let bots: [Bot] = try await client.bots()
@@ -89,7 +87,7 @@ final class Sync: AsyncParsableCommand, Route, Stored, Logged {
         }
         
         let end = Date()
-        Self.logger.notice("Syncing Complete", metadata: [
+        Logger.xcscli.notice("Syncing Complete", metadata: [
             "Seconds": .string("\(end.timeIntervalSince(start))"),
             "StoreURL": .string(storeURL.rawValue.path)
         ])

--- a/Sources/xcscli/Versions.swift
+++ b/Sources/xcscli/Versions.swift
@@ -4,7 +4,7 @@ import XcodeServer
 import XcodeServerAPI
 import Logging
 
-final class Versions: AsyncParsableCommand, Route, Logged {
+final class Versions: AsyncParsableCommand, Routed, Credentialed, Logged {
     
     static var configuration: CommandConfiguration = {
         return CommandConfiguration(

--- a/Sources/xcscli/Versions.swift
+++ b/Sources/xcscli/Versions.swift
@@ -37,6 +37,8 @@ final class Versions: AsyncParsableCommand, Route, Logged {
     }
     
     func run() async throws {
+        ConsoleLogger.bootstrap(minimumLogLevel: logLevel)
+        
         let client = try XCSClient(fqdn: server, credentialDelegate: self)
         let versions = try await client.versions()
         print(versions.asPrettyJSON() ?? "OK")


### PR DESCRIPTION
Adds the ability to remove Bots and Integrations that are no longer present on the server from the local persistence database. (The default is to retain all information)

This also represents a departure from using the `xcscli sync` command. Going forward, all interactions with the local persistence store will use the `xcscli store` and subcommands.